### PR TITLE
Add bandit class

### DIFF
--- a/bandit.ipynb
+++ b/bandit.ipynb
@@ -70,7 +70,7 @@
     "    def predict(self, X, deterministic=True):\n",
     "        predictions = self.predict_proba(X)\n",
     "        if deterministic:\n",
-    "            return predictions.argmax()\n",
+    "            return predictions.argmax(axis=1)\n",
     "        cumsum = predictions.cumsum(axis=1)\n",
     "        random_val = np.random.random_sample(len(cumsum))\n",
     "        binarized = (cumsum.T < random_val).astype(int).sum(axis=0)\n",

--- a/bandit.ipynb
+++ b/bandit.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "billion-table",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from scipy.special import softmax\n",
+    "\n",
+    "n_match_picks = 1000\n",
+    "n_context_features = 8\n",
+    "n_arms = 7\n",
+    "\n",
+    "X_context = np.random.randint(10, size=(n_match_picks, n_context_features))\n",
+    "X_action = np.random.randint(10, size=(n_match_picks, 1))\n",
+    "Y_reward = np.random.randint(10, size=(n_match_picks, 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "impressed-fossil",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((1000, 8), (1000, 1), (1000, 1))"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_context.shape, X_action.shape, Y_reward.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 210,
+   "id": "cathedral-investment",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Bandit(object):\n",
+    "    def __init__(self, n_context_features, n_arms, step_size=0.05, baseline=False):\n",
+    "        self.n_context_features = n_context_features\n",
+    "        self.n_arms = n_arms\n",
+    "        self.step_size = step_size\n",
+    "        self.baseline = baseline\n",
+    "        self.reward_sum = 0\n",
+    "        self.iters = 0\n",
+    "\n",
+    "        # start at uniform\n",
+    "        self.theta = np.zeros((self.n_context_features, self.n_arms))\n",
+    "        \n",
+    "    @property\n",
+    "    def current_baseline(self):\n",
+    "        return self.reward_sum / self.iters if self.baseline and self.iters else 0\n",
+    "        \n",
+    "    def predict_proba(self, X):\n",
+    "        return softmax((X @ self.theta).reshape(-1, self.n_arms), axis=1)\n",
+    "    \n",
+    "    def predict(self, X, deterministic=True):\n",
+    "        predictions = self.predict_proba(X)\n",
+    "        if deterministic:\n",
+    "            return predictions.argmax()\n",
+    "        cumsum = predictions.cumsum(axis=1)\n",
+    "        random_val = np.random.random_sample(len(cumsum))\n",
+    "        binarized = (cumsum.T < random_val).astype(int).sum(axis=0)\n",
+    "        return binarized\n",
+    "    \n",
+    "    def theta_gradient(self, X, actual_action):\n",
+    "        return np.eye(self.n_arms)[actual_action].squeeze() - self.predict_proba(X)\n",
+    "    \n",
+    "    def update_theta(self, X, action, reward):\n",
+    "        self.reward_sum += reward.sum()\n",
+    "        self.iters += len(reward)\n",
+    "        self.theta = self.theta + self.step_size * (reward.T - self.current_baseline) @ self.theta_gradient(X, action)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 211,
+   "id": "honest-virgin",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[0. 0. 0. 0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0. 0. 0. 0.]]\n",
+      "[[-0.06428571  0.33571429 -0.06428571 -0.01428571 -0.06428571 -0.06428571\n",
+      "  -0.06428571]\n",
+      " [-0.06428571  0.33571429 -0.06428571 -0.01428571 -0.06428571 -0.06428571\n",
+      "  -0.06428571]\n",
+      " [-0.06428571  0.33571429 -0.06428571 -0.01428571 -0.06428571 -0.06428571\n",
+      "  -0.06428571]\n",
+      " [-0.06428571  0.33571429 -0.06428571 -0.01428571 -0.06428571 -0.06428571\n",
+      "  -0.06428571]\n",
+      " [-0.06428571  0.33571429 -0.06428571 -0.01428571 -0.06428571 -0.06428571\n",
+      "  -0.06428571]\n",
+      " [-0.06428571  0.33571429 -0.06428571 -0.01428571 -0.06428571 -0.06428571\n",
+      "  -0.06428571]\n",
+      " [-0.06428571  0.33571429 -0.06428571 -0.01428571 -0.06428571 -0.06428571\n",
+      "  -0.06428571]\n",
+      " [-0.06428571  0.33571429 -0.06428571 -0.01428571 -0.06428571 -0.06428571\n",
+      "  -0.06428571]]\n",
+      "[[ 0.     0.175  0.    -0.175  0.     0.     0.   ]\n",
+      " [ 0.     0.175  0.    -0.175  0.     0.     0.   ]\n",
+      " [ 0.     0.175  0.    -0.175  0.     0.     0.   ]\n",
+      " [ 0.     0.175  0.    -0.175  0.     0.     0.   ]\n",
+      " [ 0.     0.175  0.    -0.175  0.     0.     0.   ]\n",
+      " [ 0.     0.175  0.    -0.175  0.     0.     0.   ]\n",
+      " [ 0.     0.175  0.    -0.175  0.     0.     0.   ]\n",
+      " [ 0.     0.175  0.    -0.175  0.     0.     0.   ]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "bandit = Bandit(n_context_features, n_arms)\n",
+    "bandit.predict_proba(X_context[:2])\n",
+    "bandit.predict(X_context[0], deterministic=False)\n",
+    "bandit.predict(X_context[:2], deterministic=False)\n",
+    "bandit.predict(X_context[0], deterministic=True)\n",
+    "bandit.theta_gradient(X_context[0], X_action[0])\n",
+    "bandit.theta_gradient(X_context[:2], X_action[:2])\n",
+    "print(bandit.theta)\n",
+    "bandit.update_theta(X_context[:2], X_action[:2], Y_reward[:2])\n",
+    "print(bandit.theta)\n",
+    "bandit = Bandit(n_context_features, n_arms, baseline=True)\n",
+    "bandit.update_theta(X_context[:2], X_action[:2], Y_reward[:2])\n",
+    "print(bandit.theta)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "molecular-sentence",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/bandit.py
+++ b/bandit.py
@@ -29,7 +29,7 @@ class Bandit(object):
     def predict(self, X, deterministic=True):
         predictions = self.predict_proba(X)
         if deterministic:
-            return predictions.argmax()
+            return predictions.argmax(axis=1)
         cumsum = predictions.cumsum(axis=1)
         random_val = np.random.random_sample(len(cumsum))
         binarized = (cumsum.T < random_val).astype(int).sum(axis=0)

--- a/bandit.py
+++ b/bandit.py
@@ -1,0 +1,45 @@
+#! /usr/bin/env python3
+
+import numpy as np
+import pandas as pd
+from scipy.special import softmax
+
+
+class Bandit(object):
+    def __init__(self, n_features, n_arms, step_size=0.05, baseline=False):
+        self.n_features = n_features
+        self.n_arms = n_arms
+        self.step_size = step_size
+        self.baseline = baseline
+        self.reward_sum = 0
+        self.iters = 0
+
+        # start at uniform
+        self.theta = np.zeros((self.n_features, self.n_arms))
+        
+    @property
+    def current_baseline(self):
+        return (self.reward_sum / self.iters
+                if self.baseline and self.iters
+                else 0)
+        
+    def predict_proba(self, X):
+        return softmax((X @ self.theta).reshape(-1, self.n_arms), axis=1)
+    
+    def predict(self, X, deterministic=True):
+        predictions = self.predict_proba(X)
+        if deterministic:
+            return predictions.argmax()
+        cumsum = predictions.cumsum(axis=1)
+        random_val = np.random.random_sample(len(cumsum))
+        binarized = (cumsum.T < random_val).astype(int).sum(axis=0)
+        return binarized
+    
+    def theta_gradient(self, X, action):
+        return np.eye(self.n_arms)[action].squeeze() - self.predict_proba(X)
+    
+    def update_theta(self, X, action, reward):
+        self.reward_sum += reward.sum()
+        self.iters += len(reward)
+        r_t = reward.T - self.current_baseline
+        self.theta += self.step_size * r_t @ self.theta_gradient(X, action)


### PR DESCRIPTION
First version of the bandit class. It's using policy gradient to update the `theta` params which are actually serving as a weighted sum of the context, *not* as the raw preference for each action like in the slides. Most probably, we'll call this with "epochs" or via random sampling of the context/action/reward pairs we have in our data.

I'd greatly appreciate a code review so we know I was not sleep deprived when I wrote this. (I was.)

Usage:

```python
bandit = Bandit(n_context_features, n_arms)

# get action probabilities
bandit.predict_proba(X_context[:2])

# get actions with highest probability
bandit.predict(X_context[:2], deterministic=True)

# get actions via random sampling
bandit.predict(X_context[:2], deterministic=False)

# update theta parameters
bandit.update_theta(X_context[:2], X_action[:2], Y_reward[:2])

# also available: baseline, currently just mean reward so far (not per-action)
bandit = Bandit(n_context_features, n_arms, baseline=True)
bandit.update_theta(X_context[:2], X_action[:2], Y_reward[:2])  # different theta than earlier

# get theta params
print(bandit.theta)
```
