### PR TITLE
Context extraction

### DIFF
--- a/context_engineering_functions.py
+++ b/context_engineering_functions.py
@@ -35,7 +35,7 @@ def get_basic_rewards(map_picks, demos):
 
     #drop extra WinnerId column since we no longer need it
     map_picks.dropna(inplace= True, axis = 0)
-    map_picks.drop(labels = [ 'Created', 'Updated', 'WinnerId'], axis = 1, inplace = True)
+    map_picks.drop(labels = ['WinnerId'], axis = 1, inplace = True)
 
     return map_picks
 
@@ -53,6 +53,8 @@ def create_basic_triples(data_directory, save = False):
                                 'WinnerSecondHalfScore', 'WinnerFirstHalfSide', 'WinnerOTScore', 'LoserId', 'LoserScore',
                                 'LoserFirstHalfScore', 'LoserSecondHalfScore', 'LoserFirstHalfSide', 'LoserOTScore',
                                 'DemoParsed', 'Created', 'Updated'])
+
+    map_picks.drop(labels = ['Created', 'Updated'], axis = 1, inplace = True)
 
     map_encoder = {MapName: index for index, MapName in enumerate(sorted(map_picks.MapName.unique()))}
 
@@ -75,13 +77,12 @@ def create_basic_triples(data_directory, save = False):
     
     if save:
         map_pick_context.to_csv(os.path.join(data_directory, 'basic_triples.csv'))
-        print('Finished Basic Context Engineering')
         return map_pick_context
 
     else:
         return map_pick_context
 
-
+    print('Finished Basic Context Engineering')
 
 
 

--- a/context_engineering_functions.py
+++ b/context_engineering_functions.py
@@ -1,0 +1,86 @@
+import pandas as pd
+import os
+
+def get_available_maps(map_picks):
+    map_picks.sort_values(by=['MatchId', 'DecisionOrder'], ascending=True, inplace=True)
+    map_names = map_picks['MapName'].unique().tolist()
+
+    # get which map we're talking about, OHE
+    manip_df = pd.concat([map_picks[['MatchId']], pd.get_dummies(map_picks['MapName'])], axis=1)
+    # 1 - what's not available
+    rolling_df = (1 - (manip_df.groupby('MatchId')[map_names]
+                               .rolling(7, min_periods=0)
+                               .sum()  # rolling sum
+                               .shift(1, fill_value=0)  # shift down so we know what's available
+                               ))
+    rolling_df = rolling_df.astype(int)
+    rolling_df.reset_index(drop=True, inplace=True)
+    rolling_df.columns = [x + '_is_available' for x in rolling_df.columns]
+    rolling_df
+    map_picks = pd.concat([map_picks, rolling_df], axis=1)
+    return map_picks
+
+def get_rewards(map_picks, demos):
+    map_picks =  pd.merge(map_picks,
+                          demos[['MatchId', 'MapName', 'WinnerId']], 
+                          how = 'left', 
+                          left_on= ['MatchId', 'MapName'], 
+                          right_on = ['MatchId', 'MapName'],
+                          suffixes = (None, '_right'))
+    #for picks, if winner is same as picker, reward 1
+    map_picks['Y_reward'] = (map_picks.DecisionTeamId == map_picks.WinnerId).astype(int)
+
+    #drop extra WinnerId column since we no longer need it
+    map_picks.drop(labels = [ 'Created', 'Updated', 'WinnerId'], axis = 1, inplace = True)
+
+    return map_picks
+
+
+def create_basic_triples(data_directory, save = False):
+    map_picks = pd.read_csv(os.path.join(data_directory, 'map_picks.csv'),
+                            header = None, 
+                            names = ['MatchId', 'MapName', 'DecisionOrder', 
+                                      'DecisionTeamId', 'OtherTeamId',
+                                      'Decision','Created', 'Updated'] )
+
+    demos =  pd.read_csv(os.path.join(data_directory, 'demos.csv'),
+                        header = None,
+                        names = ['MatchId', 'MapName', 'WinnerId', 'WinnerScore', 'WinnerFirstHalfScore', 
+                                  'WinnerSecondHalfScore', 'WinnerFirstHalfSide', 'WinnerOTScore', 'LoserId', 'LoserScore',
+                                  'LoserFirstHalfScore', 'LoserSecondHalfScore', 'LoserFirstHalfSide', 'LoserOTScore',
+                                'DemoParsed', 'Created', 'Updated'])
+
+
+    map_encoder = {MapName: index for index, MapName in enumerate(sorted(map_picks.MapName.unique()))}
+
+    map_picks = map_picks[map_picks.Decision == 'Pick']
+
+    map_picks.drop(labels = 'Decision', axis = 1, inplace = True)
+
+    map_pick_context = get_rewards(map_picks, demos)
+    map_pick_context = get_available_maps(map_pick_context)
+
+    map_pick_context.MapName = map_pick_context.MapName.map(map_encoder)
+
+    map_pick_context.rename(columns = {'MapName': 'X_Action'}, inplace = True)
+    map_pick_context.sort_values(by = ['MatchId', 'DecisionOrder'], inplace = True)
+
+
+    cols = ['MatchId'] + \
+          [i+'_is_available' for i in map_encoder.keys()] + \
+           ['DecisionTeamId', 'OtherTeamId','DecisionOrder', 'X_Action','Y_reward' ]
+    
+    map_pick_context = map_pick_context[cols]
+    
+
+    if save:
+        map_pick_context.to_csv(os.path.join(data_directory, 'basic_triples.csv'))
+        print('Finished Basic Context Engineering')
+
+    else:
+        return map_pick_context
+
+
+
+
+

--- a/context_engineering_functions.py
+++ b/context_engineering_functions.py
@@ -45,11 +45,10 @@ def create_basic_triples(data_directory, save = False):
 
     demos =  pd.read_csv(os.path.join(data_directory, 'demos.csv'), header = None)
 
-    map_picks.drop(labels = ['Created', 'Updated'], axis = 1, inplace = True)
-
     map_encoder = {MapName: index for index, MapName in enumerate(sorted(map_picks.MapName.unique()))}
 
     map_pick_context = get_available_maps(map_picks)
+    
     map_pick_context = map_pick_context[map_picks.Decision == 'Pick']
 
     map_pick_context.drop(labels = 'Decision', axis = 1, inplace = True)

--- a/context_engineering_functions.py
+++ b/context_engineering_functions.py
@@ -41,18 +41,9 @@ def get_basic_rewards(map_picks, demos):
 
 
 def create_basic_triples(data_directory, save = False):
-    map_picks = pd.read_csv(os.path.join(data_directory, 'map_picks.csv'),
-                            header = None, 
-                            names = ['MatchId', 'MapName', 'DecisionOrder', 
-                                    'DecisionTeamId', 'OtherTeamId',
-                                    'Decision','Created', 'Updated'] )
+    map_picks = pd.read_csv(os.path.join(data_directory, 'map_picks.csv'), header = None)
 
-    demos =  pd.read_csv(os.path.join(data_directory, 'demos.csv'),
-                        header = None,
-                        names = ['MatchId', 'MapName', 'WinnerId', 'WinnerScore', 'WinnerFirstHalfScore', 
-                                'WinnerSecondHalfScore', 'WinnerFirstHalfSide', 'WinnerOTScore', 'LoserId', 'LoserScore',
-                                'LoserFirstHalfScore', 'LoserSecondHalfScore', 'LoserFirstHalfSide', 'LoserOTScore',
-                                'DemoParsed', 'Created', 'Updated'])
+    demos =  pd.read_csv(os.path.join(data_directory, 'demos.csv'), header = None)
 
     map_picks.drop(labels = ['Created', 'Updated'], axis = 1, inplace = True)
 
@@ -71,7 +62,7 @@ def create_basic_triples(data_directory, save = False):
 
     cols = ['MatchId'] + \
           [i+'_is_available' for i in map_encoder.keys()] + \
-          ['DecisionTeamId', 'OtherTeamId','DecisionOrder', 'X_Action','Y_reward' ]
+          ['DecisionTeamId', 'OtherTeamId','DecisionOrder', 'X_Action','Y_reward']
     
     map_pick_context = map_pick_context[cols]
     

--- a/context_engineering_functions.py
+++ b/context_engineering_functions.py
@@ -17,17 +17,17 @@ def get_available_maps(df):
                                .shift(1, fill_value=0)  # shift down so we know what's available
                                ))
     rolling_df = rolling_df.astype(int)
-    rolling_df.reset_index(drop=True, inplace=True)
+    rolling_df.reset_index(drop = True, inplace=True)
     rolling_df.columns = [x + '_is_available' for x in rolling_df.columns]
 
     df = pd.concat([df, rolling_df], axis=1)
     return df
 
-def get_rewards(map_picks, demos):
+def get_basic_rewards(map_picks, demos):
     map_picks =  pd.merge(map_picks,
                           demos[['MatchId', 'MapName', 'WinnerId']], 
                           how = 'left', 
-                          left_on= ['MatchId', 'MapName'], 
+                          left_on = ['MatchId', 'MapName'], 
                           right_on = ['MatchId', 'MapName'],
                           suffixes = (None, '_right'))
     #for picks, if winner is same as picker, reward 1
@@ -44,16 +44,15 @@ def create_basic_triples(data_directory, save = False):
     map_picks = pd.read_csv(os.path.join(data_directory, 'map_picks.csv'),
                             header = None, 
                             names = ['MatchId', 'MapName', 'DecisionOrder', 
-                                      'DecisionTeamId', 'OtherTeamId',
-                                      'Decision','Created', 'Updated'] )
+                                    'DecisionTeamId', 'OtherTeamId',
+                                    'Decision','Created', 'Updated'] )
 
     demos =  pd.read_csv(os.path.join(data_directory, 'demos.csv'),
                         header = None,
                         names = ['MatchId', 'MapName', 'WinnerId', 'WinnerScore', 'WinnerFirstHalfScore', 
-                                  'WinnerSecondHalfScore', 'WinnerFirstHalfSide', 'WinnerOTScore', 'LoserId', 'LoserScore',
-                                  'LoserFirstHalfScore', 'LoserSecondHalfScore', 'LoserFirstHalfSide', 'LoserOTScore',
+                                'WinnerSecondHalfScore', 'WinnerFirstHalfSide', 'WinnerOTScore', 'LoserId', 'LoserScore',
+                                'LoserFirstHalfScore', 'LoserSecondHalfScore', 'LoserFirstHalfSide', 'LoserOTScore',
                                 'DemoParsed', 'Created', 'Updated'])
-
 
     map_encoder = {MapName: index for index, MapName in enumerate(sorted(map_picks.MapName.unique()))}
 
@@ -62,25 +61,22 @@ def create_basic_triples(data_directory, save = False):
 
     map_pick_context.drop(labels = 'Decision', axis = 1, inplace = True)
 
-    map_pick_context = get_rewards(map_pick_context, demos)
-
+    map_pick_context = get_basic_rewards(map_pick_context, demos)
 
     map_pick_context.MapName = map_pick_context.MapName.map(map_encoder)
 
     map_pick_context.rename(columns = {'MapName': 'X_Action'}, inplace = True)
 
-
-
     cols = ['MatchId'] + \
           [i+'_is_available' for i in map_encoder.keys()] + \
-           ['DecisionTeamId', 'OtherTeamId','DecisionOrder', 'X_Action','Y_reward' ]
+          ['DecisionTeamId', 'OtherTeamId','DecisionOrder', 'X_Action','Y_reward' ]
     
     map_pick_context = map_pick_context[cols]
     
-
     if save:
         map_pick_context.to_csv(os.path.join(data_directory, 'basic_triples.csv'))
         print('Finished Basic Context Engineering')
+        return map_pick_context
 
     else:
         return map_pick_context

--- a/context_engineering_functions.py
+++ b/context_engineering_functions.py
@@ -65,7 +65,7 @@ def create_basic_triples(data_directory, save = False):
           ['DecisionTeamId', 'OtherTeamId','DecisionOrder', 'X_Action','Y_reward']
     
     map_pick_context = map_pick_context[cols]
-    
+    print('Finished Basic Context Engineering')
     if save:
         map_pick_context.to_csv(os.path.join(data_directory, 'basic_triples.csv'))
         return map_pick_context
@@ -73,7 +73,7 @@ def create_basic_triples(data_directory, save = False):
     else:
         return map_pick_context
 
-    print('Finished Basic Context Engineering')
+
 
 
 

--- a/context_engineering_test.py
+++ b/context_engineering_test.py
@@ -4,8 +4,8 @@ import sys
 
 
 def main(datapath):
-    context = cef.create_basic_triples(datapath, save = False)
-    print(context.head(20))
+ 	cef.create_basic_triples(datapath, save = True)
+
 
 if __name__ == "__main__":
     filepath = sys.argv[1]

--- a/context_engineering_test.py
+++ b/context_engineering_test.py
@@ -1,0 +1,13 @@
+import pandas as pd
+import context_engineering_functions as cef
+import sys
+
+
+def main(datapath):
+    context = cef.create_basic_triples(datapath, save = False)
+    print(context.head(10))
+
+if __name__ == "__main__":
+    filepath = sys.argv[1]
+    main(filepath)
+

--- a/context_engineering_test.py
+++ b/context_engineering_test.py
@@ -5,7 +5,7 @@ import sys
 
 def main(datapath):
     context = cef.create_basic_triples(datapath, save = False)
-    print(context.head(10))
+    print(context.head(20))
 
 if __name__ == "__main__":
     filepath = sys.argv[1]


### PR DESCRIPTION
I started off the context engineering, keeping it very basic such that the output df is:

[map_is_available(x7), DecisionTeamId, OtherTeamId, DecisionOrder, X_action, Y_reward]

X_action is a label encoded id for the map, and Y_reward is the 0-1 loss for whether the DecidingTeam won on that map or not. I dropped all rows where the map was picked, but the game was not played(usually the third game if one team had already won 2 games)

The questionable column right now is DecisionOrder - Since we are only taking map picks, it seems unnecessary to utilize it since all the decision orders are the same. On top of that, we can always infer the decision order since we know the number of available maps. 

If anyone has other ideas of other context, let me know, but I'm just PRing this branch so we have something very easy to start testing the bandit class out with!

EDIT: The function just takes the path to the directory where all the csvs are located, you can try it out with the context_engineering_test.py file