### PR TITLE
Data Cleaning notebook

### DIFF
--- a/data_cleaning.ipynb
+++ b/data_cleaning.ipynb
@@ -1,0 +1,638 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cols_demos = [\n",
+    "    'MatchId',\n",
+    "    'MapName' ,\n",
+    "    'WinnerId' ,\n",
+    "    'WinnerScore' ,\n",
+    "    'WinnerFirstHalfScore' ,\n",
+    "    'WinnerSecondHalfScore' ,\n",
+    "    'WinnerFirstHalfSide' ,\n",
+    "    'WinnerOTScore' ,\n",
+    "    'LoserId' ,\n",
+    "    'LoserScore' ,\n",
+    "    'LoserFirstHalfScore' ,\n",
+    "    'LoserSecondHalfScore' ,\n",
+    "    'LoserFirstHalfSide' ,\n",
+    "    'LoserOTScore' ,\n",
+    "    'DemoParsed' ,\n",
+    "    'Created' ,\n",
+    "    'Updated']\n",
+    "cols_map_picks = [\n",
+    "    'MatchId',\n",
+    "    'MapName',\n",
+    "    'DecisionOrder',\n",
+    "    'DecisionTeamId',\n",
+    "    'OtherTeamId',\n",
+    "    'Decision',\n",
+    "    'Created',\n",
+    "    'Updated']\n",
+    "cols_matches = [\n",
+    "    'MatchId',\n",
+    "    'HLTVMatchId',\n",
+    "    'CompetitionId',\n",
+    "    'HLTVLink',\n",
+    "    'MatchType',\n",
+    "    'MatchDate',\n",
+    "    'MatchTime',\n",
+    "    'Stars',\n",
+    "    'Slug',\n",
+    "    'WinnerId',\n",
+    "    'WinnerScore',\n",
+    "    'LoserId',\n",
+    "    'LoserScore',\n",
+    "    'Created',\n",
+    "    'Updated']\n",
+    "cols_teams = [\n",
+    "    'TeamId',\n",
+    "    'HLTVTeamId',\n",
+    "    'HLTVLink',\n",
+    "    'TeamName',\n",
+    "    'Country',\n",
+    "    'Twitter',\n",
+    "    'Facebook',\n",
+    "    'Created',\n",
+    "    'Updated']\n",
+    "cols_player_demos = [\n",
+    "    'MatchId',\n",
+    "    'PlayerId',\n",
+    "    'TeamId',\n",
+    "    'MapName',\n",
+    "    'Side',\n",
+    "    'Kills',\n",
+    "    'Deaths',\n",
+    "    'ADR',\n",
+    "    'KAST',\n",
+    "    'HLTVRating',\n",
+    "    'Created',\n",
+    "    'Updated']\n",
+    "cols_players = [\n",
+    "    'PlayerId',\n",
+    "    'HLTVPlayerId',\n",
+    "    'HLTVLink',\n",
+    "    'Country',\n",
+    "    'RealName',\n",
+    "    'PlayerName',\n",
+    "    'Facebook',\n",
+    "    'Twitter',\n",
+    "    'Twitch',\n",
+    "    'Created',\n",
+    "    'Updated']\n",
+    "data_dir = '../data/'\n",
+    "demos = pd.read_csv(data_dir+'demos.csv',names = cols_demos)\n",
+    "map_picks = pd.read_csv(data_dir+'map_picks.csv',names = cols_map_picks)\n",
+    "matches = pd.read_csv(data_dir+'matches.csv',names = cols_matches)\n",
+    "teams = pd.read_csv(data_dir+'teams.csv',names = cols_teams)\n",
+    "players = pd.read_csv(data_dir+'players.csv',names = cols_players)\n",
+    "player_demos = pd.read_csv(data_dir+'player_demos.csv',names = cols_player_demos)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_team_record_df(teams,demos):\n",
+    "    '''Creates team_record dataframe where each row is a Team, columns are various stats.\n",
+    "       Inputs are dataframes of the .csvs of the same name.\n",
+    "       Output is a dataframe indexed by teamid'''\n",
+    "    # All team IDs\n",
+    "    team_record = pd.DataFrame(teams['TeamId'].unique().astype(int),columns=['TeamId'])\n",
+    "    # Wins and losses (For games, not matches) by team ID\n",
+    "    game_wins = demos['WinnerId'].value_counts()\n",
+    "    game_losses = demos['LoserId'].value_counts()\n",
+    "    # merge wins and losses \n",
+    "    team_record = team_record.merge(game_wins,left_on='TeamId',right_index=True,how='left').fillna(0).astype(int)\n",
+    "    team_record = team_record.merge(game_losses,left_on='TeamId',right_index=True,how='left').fillna(0).astype(int)\n",
+    "    team_record.rename(columns={\"WinnerId\": \"GameWins\", \"LoserId\": \"GameLosses\"},inplace=True)\n",
+    "    team_record['TotalGames'] = team_record['GameWins']+team_record['GameLosses'].astype(int)\n",
+    "    team_record['WinPercent'] = (team_record['GameWins']/team_record['TotalGames']).fillna(0)\n",
+    "    # Set index to team_id, to simplify things\n",
+    "    team_record.set_index('TeamId',drop=False,inplace=True)\n",
+    "    return team_record    \n",
+    "\n",
+    "def win_pct_by_map(demos,team_record):\n",
+    "    '''Calculates win percentage by map for teams in team_record \n",
+    "       and appends win/loss/matches/win_pct columns to team_record.\n",
+    "       demos - the demos dataframe, no alterations\n",
+    "       team_record - output of build_team_record_df, or a filtered version (i.e. removing few-match teams)\n",
+    "       '''\n",
+    "    \n",
+    "    # Count wins and losses by map and by team\n",
+    "    wins = demos.groupby(['WinnerId','MapName']).count()['MatchId']\n",
+    "    losses = demos.groupby(['LoserId','MapName']).count()['MatchId']\n",
+    "    \n",
+    "    # Fills the dataframe with wins and losses, sums for matches, divides for win_pct\n",
+    "    for m in demos['MapName'].unique():\n",
+    "        for t in team_record['TeamId']:\n",
+    "            # Wins\n",
+    "            try:\n",
+    "                team_record.loc[t,m+'_wins'] = wins[(t,m)]\n",
+    "            except KeyError:\n",
+    "                team_record.loc[t,m+'_wins'] = 0\n",
+    "            # Losses\n",
+    "            try:\n",
+    "                team_record.loc[t,m+'_losses'] = losses[(t,m)]\n",
+    "            except KeyError:\n",
+    "                team_record.loc[t,m+'_losses'] = 0\n",
+    "        team_record[m+'_games'] = team_record[m+'_wins'] + team_record[m+'_losses']\n",
+    "        # Map level win percentage\n",
+    "        team_record[m+'_win_pct'] = team_record[m+'_wins'] / team_record[m+'_games']\n",
+    "\n",
+    "    return team_record"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def remove_records(df,cols,remove_ids):\n",
+    "    # Function removes rows where df[cols] value is in remove_ids\n",
+    "    # Returns df with same columns and fewer rows\n",
+    "\n",
+    "    few_games_dict = {tid: [] for tid in cols}\n",
+    "    out = [False]*df.shape[0]\n",
+    "    for col in cols:\n",
+    "        a = [t in remove_ids for t in df[col]]\n",
+    "        out = [a or b for (a,b) in zip(out,a)]\n",
+    "    df['remove'] = out\n",
+    "    print(\"Num removed: \",df['remove'].sum())\n",
+    "    # Remove bad records\n",
+    "    df_out = df[df['remove']==False]\n",
+    "    df_out = df_out.drop(['remove'],axis=1)\n",
+    "\n",
+    "    return df_out"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Matches without map_picks data\n",
+    "26 maps in matches.csv do not have map_pick records. 24 of those are also in demos.csv. Removing those."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "26\n"
+     ]
+    }
+   ],
+   "source": [
+    "matches_match_ids = matches['MatchId'].unique()\n",
+    "map_pick_match_ids = map_picks['MatchId'].unique()\n",
+    "demos_match_ids = demos['MatchId'].unique()\n",
+    "no_map_picks = []\n",
+    "\n",
+    "for m in matches_match_ids:\n",
+    "    if m not in map_pick_match_ids:\n",
+    "        no_map_picks.append(m)\n",
+    "\n",
+    "for m in demos_match_ids:\n",
+    "    if m not in map_pick_match_ids:\n",
+    "        no_map_picks.append(m)\n",
+    "\n",
+    "no_map_picks = set(no_map_picks)\n",
+    "print(len(no_map_picks))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Num removed:  41\n",
+      "Num removed:  0\n",
+      "Num removed:  26\n"
+     ]
+    }
+   ],
+   "source": [
+    "demos = remove_records(demos,['MatchId'],no_map_picks)\n",
+    "player_demos = remove_records(player_demos,['MatchId'],no_map_picks)\n",
+    "matches = remove_records(matches,['MatchId'],no_map_picks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(636, 9)\n",
+      "(43705, 8)\n",
+      "(6257, 15)\n",
+      "(13113, 17)\n",
+      "(392640, 12)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(teams.shape)\n",
+    "print(map_picks.shape)\n",
+    "print(matches.shape)\n",
+    "print(demos.shape)\n",
+    "print(player_demos.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Remove Weird other maps\n",
+    "Three maps only appear about 5 times, removing them. Note: I guess they got cleared out in a previous filter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weird_maps = ['de_tuscan','de_cobblestone','de_cache']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Num removed:  0\n",
+      "Num removed:  0\n",
+      "Num removed:  0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Label each record with T/F if a team involved has fewer than min_games\n",
+    "demos = remove_records(demos,['MapName'],weird_maps)\n",
+    "map_picks = remove_records(map_picks,['MapName'],weird_maps)\n",
+    "player_demos = remove_records(player_demos,['MapName'],weird_maps)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(636, 9)\n",
+      "(43705, 8)\n",
+      "(6257, 15)\n",
+      "(13113, 17)\n",
+      "(392640, 12)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(teams.shape)\n",
+    "print(map_picks.shape)\n",
+    "print(matches.shape)\n",
+    "print(demos.shape)\n",
+    "print(player_demos.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Remove matches where Decision 1 was a Pick\n",
+    "This happens ~3 times"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wrong_decision_match_ids = list(map_picks[(map_picks['Decision']=='Pick') & (map_picks['DecisionOrder']==1)]['MatchId'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Num removed:  8\n",
+      "Num removed:  240\n",
+      "Num removed:  3\n"
+     ]
+    }
+   ],
+   "source": [
+    "demos = remove_records(demos,['MatchId'],wrong_decision_match_ids)\n",
+    "player_demos = remove_records(player_demos,['MatchId'],wrong_decision_match_ids)\n",
+    "matches = remove_records(matches,['MatchId'],wrong_decision_match_ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(636, 9)\n",
+      "(43705, 8)\n",
+      "(6254, 15)\n",
+      "(13105, 17)\n",
+      "(392400, 12)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(teams.shape)\n",
+    "print(map_picks.shape)\n",
+    "print(matches.shape)\n",
+    "print(demos.shape)\n",
+    "print(player_demos.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Teams with fewer than min_games\n",
+    "After the other filters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Round  0\n",
+      "Num removed:  427\n",
+      "Num removed:  2431\n",
+      "Num removed:  9008\n",
+      "Num removed:  43981\n",
+      "Round  1\n",
+      "Num removed:  25\n",
+      "Num removed:  434\n",
+      "Num removed:  1819\n",
+      "Num removed:  11756\n",
+      "Round  2\n",
+      "Num removed:  4\n",
+      "Num removed:  77\n",
+      "Num removed:  315\n",
+      "Num removed:  2180\n",
+      "Round  3\n",
+      "Num removed:  0\n",
+      "Num removed:  0\n",
+      "Num removed:  0\n",
+      "Num removed:  0\n",
+      "Round  4\n",
+      "Num removed:  0\n",
+      "Num removed:  0\n",
+      "Num removed:  0\n",
+      "Num removed:  0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Team Ids for teams with fewer than 25 games\n",
+    "min_games = 25\n",
+    "\n",
+    "# Repeat to remove teams that fall below 25 games when others are removed\n",
+    "for i in range(5):\n",
+    "    print(\"Round \",i)\n",
+    "    team_record = build_team_record_df(teams,demos)\n",
+    "    few_games_team_ids = team_record[team_record['TotalGames']<min_games]['TeamId']\n",
+    "    # Label each record with T/F if a team involved has fewer than min_games\n",
+    "    teams = remove_records(teams,['TeamId'],few_games_team_ids)\n",
+    "    demos = remove_records(demos,['WinnerId','LoserId'],few_games_team_ids)\n",
+    "    map_picks = remove_records(map_picks,['DecisionTeamId','OtherTeamId'],few_games_team_ids)\n",
+    "    player_demos = remove_records(player_demos,['TeamId'],few_games_team_ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(180, 9)\n",
+      "(32563, 8)\n",
+      "(6254, 15)\n",
+      "(10163, 17)\n",
+      "(334483, 12)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(teams.shape)\n",
+    "print(map_picks.shape)\n",
+    "print(matches.shape)\n",
+    "print(demos.shape)\n",
+    "print(player_demos.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Repeat: Matches without map_picks data\n",
+    "26 maps in matches.csv do not have map_pick records. 24 of those are also in demos.csv. Removing those.\n",
+    "Repeating here because more dangling matches get removed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1596\n"
+     ]
+    }
+   ],
+   "source": [
+    "matches_match_ids = matches['MatchId'].unique()\n",
+    "map_pick_match_ids = map_picks['MatchId'].unique()\n",
+    "demos_match_ids = demos['MatchId'].unique()\n",
+    "no_map_picks = []\n",
+    "\n",
+    "for m in matches_match_ids:\n",
+    "    if m not in map_pick_match_ids:\n",
+    "        no_map_picks.append(m)\n",
+    "\n",
+    "for m in demos_match_ids:\n",
+    "    if m not in map_pick_match_ids:\n",
+    "        no_map_picks.append(m)\n",
+    "\n",
+    "no_map_picks = set(no_map_picks)\n",
+    "print(len(no_map_picks))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Num removed:  0\n",
+      "Num removed:  30103\n",
+      "Num removed:  1596\n"
+     ]
+    }
+   ],
+   "source": [
+    "demos = remove_records(demos,['MatchId'],no_map_picks)\n",
+    "player_demos = remove_records(player_demos,['MatchId'],no_map_picks)\n",
+    "matches = remove_records(matches,['MatchId'],no_map_picks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(180, 9)\n",
+      "(32563, 8)\n",
+      "(4658, 15)\n",
+      "(10163, 17)\n",
+      "(304380, 12)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(teams.shape)\n",
+    "print(map_picks.shape)\n",
+    "print(matches.shape)\n",
+    "print(demos.shape)\n",
+    "print(player_demos.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save clean csv's"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out_dir = '../data/clean/'\n",
+    "\n",
+    "if not os.path.exists(data_dir):\n",
+    "    os.mkdir(data_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demos.to_csv(out_dir+'demos.csv',index=False)\n",
+    "map_picks.to_csv(out_dir+'map_picks.csv',index=False)\n",
+    "matches.to_csv(out_dir+'matches.csv',index=False)\n",
+    "teams.to_csv(out_dir+'teams.csv',index=False)\n",
+    "players.to_csv(out_dir+'players.csv',index=False)\n",
+    "player_demos.to_csv(out_dir+'player_demos.csv',index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/data_cleaning.ipynb
+++ b/data_cleaning.ipynb
@@ -130,37 +130,7 @@
     "    team_record['WinPercent'] = (team_record['GameWins']/team_record['TotalGames']).fillna(0)\n",
     "    # Set index to team_id, to simplify things\n",
     "    team_record.set_index('TeamId',drop=False,inplace=True)\n",
-    "    return team_record    \n",
-    "\n",
-    "def win_pct_by_map(demos,team_record):\n",
-    "    '''Calculates win percentage by map for teams in team_record \n",
-    "       and appends win/loss/matches/win_pct columns to team_record.\n",
-    "       demos - the demos dataframe, no alterations\n",
-    "       team_record - output of build_team_record_df, or a filtered version (i.e. removing few-match teams)\n",
-    "       '''\n",
-    "    \n",
-    "    # Count wins and losses by map and by team\n",
-    "    wins = demos.groupby(['WinnerId','MapName']).count()['MatchId']\n",
-    "    losses = demos.groupby(['LoserId','MapName']).count()['MatchId']\n",
-    "    \n",
-    "    # Fills the dataframe with wins and losses, sums for matches, divides for win_pct\n",
-    "    for m in demos['MapName'].unique():\n",
-    "        for t in team_record['TeamId']:\n",
-    "            # Wins\n",
-    "            try:\n",
-    "                team_record.loc[t,m+'_wins'] = wins[(t,m)]\n",
-    "            except KeyError:\n",
-    "                team_record.loc[t,m+'_wins'] = 0\n",
-    "            # Losses\n",
-    "            try:\n",
-    "                team_record.loc[t,m+'_losses'] = losses[(t,m)]\n",
-    "            except KeyError:\n",
-    "                team_record.loc[t,m+'_losses'] = 0\n",
-    "        team_record[m+'_games'] = team_record[m+'_wins'] + team_record[m+'_losses']\n",
-    "        # Map level win percentage\n",
-    "        team_record[m+'_win_pct'] = team_record[m+'_wins'] / team_record[m+'_games']\n",
-    "\n",
-    "    return team_record"
+    "    return team_record    "
    ]
   },
   {
@@ -421,16 +391,19 @@
       "Round  0\n",
       "Num removed:  427\n",
       "Num removed:  2431\n",
+      "Num removed:  1291\n",
       "Num removed:  9008\n",
       "Num removed:  43981\n",
       "Round  1\n",
       "Num removed:  25\n",
       "Num removed:  434\n",
+      "Num removed:  260\n",
       "Num removed:  1819\n",
       "Num removed:  11756\n",
       "Round  2\n",
       "Num removed:  4\n",
       "Num removed:  77\n",
+      "Num removed:  45\n",
       "Num removed:  315\n",
       "Num removed:  2180\n",
       "Round  3\n",
@@ -438,7 +411,9 @@
       "Num removed:  0\n",
       "Num removed:  0\n",
       "Num removed:  0\n",
+      "Num removed:  0\n",
       "Round  4\n",
+      "Num removed:  0\n",
       "Num removed:  0\n",
       "Num removed:  0\n",
       "Num removed:  0\n",
@@ -455,9 +430,11 @@
     "    print(\"Round \",i)\n",
     "    team_record = build_team_record_df(teams,demos)\n",
     "    few_games_team_ids = team_record[team_record['TotalGames']<min_games]['TeamId']\n",
+    "\n",
     "    # Label each record with T/F if a team involved has fewer than min_games\n",
     "    teams = remove_records(teams,['TeamId'],few_games_team_ids)\n",
     "    demos = remove_records(demos,['WinnerId','LoserId'],few_games_team_ids)\n",
+    "    matches = remove_records(matches,['WinnerId','LoserId'],few_games_team_ids)\n",
     "    map_picks = remove_records(map_picks,['DecisionTeamId','OtherTeamId'],few_games_team_ids)\n",
     "    player_demos = remove_records(player_demos,['TeamId'],few_games_team_ids)"
    ]
@@ -473,95 +450,9 @@
      "text": [
       "(180, 9)\n",
       "(32563, 8)\n",
-      "(6254, 15)\n",
-      "(10163, 17)\n",
-      "(334483, 12)\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(teams.shape)\n",
-    "print(map_picks.shape)\n",
-    "print(matches.shape)\n",
-    "print(demos.shape)\n",
-    "print(player_demos.shape)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Repeat: Matches without map_picks data\n",
-    "26 maps in matches.csv do not have map_pick records. 24 of those are also in demos.csv. Removing those.\n",
-    "Repeating here because more dangling matches get removed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1596\n"
-     ]
-    }
-   ],
-   "source": [
-    "matches_match_ids = matches['MatchId'].unique()\n",
-    "map_pick_match_ids = map_picks['MatchId'].unique()\n",
-    "demos_match_ids = demos['MatchId'].unique()\n",
-    "no_map_picks = []\n",
-    "\n",
-    "for m in matches_match_ids:\n",
-    "    if m not in map_pick_match_ids:\n",
-    "        no_map_picks.append(m)\n",
-    "\n",
-    "for m in demos_match_ids:\n",
-    "    if m not in map_pick_match_ids:\n",
-    "        no_map_picks.append(m)\n",
-    "\n",
-    "no_map_picks = set(no_map_picks)\n",
-    "print(len(no_map_picks))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Num removed:  0\n",
-      "Num removed:  30103\n",
-      "Num removed:  1596\n"
-     ]
-    }
-   ],
-   "source": [
-    "demos = remove_records(demos,['MatchId'],no_map_picks)\n",
-    "player_demos = remove_records(player_demos,['MatchId'],no_map_picks)\n",
-    "matches = remove_records(matches,['MatchId'],no_map_picks)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(180, 9)\n",
-      "(32563, 8)\n",
       "(4658, 15)\n",
       "(10163, 17)\n",
-      "(304380, 12)\n"
+      "(334483, 12)\n"
      ]
     }
    ],

--- a/data_cleaning.ipynb
+++ b/data_cleaning.ipynb
@@ -334,14 +334,16 @@
      "text": [
       "Num removed:  8\n",
       "Num removed:  240\n",
-      "Num removed:  3\n"
+      "Num removed:  3\n",
+      "Num removed:  21\n"
      ]
     }
    ],
    "source": [
     "demos = remove_records(demos,['MatchId'],wrong_decision_match_ids)\n",
     "player_demos = remove_records(player_demos,['MatchId'],wrong_decision_match_ids)\n",
-    "matches = remove_records(matches,['MatchId'],wrong_decision_match_ids)"
+    "matches = remove_records(matches,['MatchId'],wrong_decision_match_ids)\n",
+    "map_picks = remove_records(map_picks,['MatchId'],wrong_decision_match_ids)"
    ]
   },
   {
@@ -354,10 +356,79 @@
      "output_type": "stream",
      "text": [
       "(636, 9)\n",
-      "(43705, 8)\n",
+      "(43684, 8)\n",
       "(6254, 15)\n",
       "(13105, 17)\n",
       "(392400, 12)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(teams.shape)\n",
+    "print(map_picks.shape)\n",
+    "print(matches.shape)\n",
+    "print(demos.shape)\n",
+    "print(player_demos.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Matches with !=3 games"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Number of picks by match ID\n",
+    "pick_count = map_picks[map_picks['Decision']=='Pick'].groupby('MatchId').count()['MapName']\n",
+    "# Match Ids where num_picks does not equal 3\n",
+    "not_3_picks = list(pick_count[pick_count!=3].index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Num removed:  1801\n",
+      "Num removed:  53867\n",
+      "Num removed:  1564\n",
+      "Num removed:  10861\n"
+     ]
+    }
+   ],
+   "source": [
+    "demos = remove_records(demos,['MatchId'],not_3_picks)\n",
+    "player_demos = remove_records(player_demos,['MatchId'],not_3_picks)\n",
+    "matches = remove_records(matches,['MatchId'],not_3_picks)\n",
+    "map_picks = remove_records(map_picks,['MatchId'],not_3_picks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(636, 9)\n",
+      "(32823, 8)\n",
+      "(4690, 15)\n",
+      "(11304, 17)\n",
+      "(338533, 12)\n"
      ]
     }
    ],
@@ -379,7 +450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "metadata": {
     "scrolled": true
    },
@@ -389,30 +460,48 @@
      "output_type": "stream",
      "text": [
       "Round  0\n",
-      "Num removed:  427\n",
-      "Num removed:  2431\n",
-      "Num removed:  1291\n",
-      "Num removed:  9008\n",
-      "Num removed:  43981\n",
+      "Num removed:  447\n",
+      "Num removed:  2128\n",
+      "Num removed:  912\n",
+      "Num removed:  6384\n",
+      "Num removed:  39687\n",
       "Round  1\n",
-      "Num removed:  25\n",
-      "Num removed:  434\n",
-      "Num removed:  260\n",
-      "Num removed:  1819\n",
-      "Num removed:  11756\n",
+      "Num removed:  16\n",
+      "Num removed:  258\n",
+      "Num removed:  112\n",
+      "Num removed:  784\n",
+      "Num removed:  7298\n",
       "Round  2\n",
-      "Num removed:  4\n",
-      "Num removed:  77\n",
-      "Num removed:  45\n",
-      "Num removed:  315\n",
-      "Num removed:  2180\n",
+      "Num removed:  3\n",
+      "Num removed:  65\n",
+      "Num removed:  27\n",
+      "Num removed:  189\n",
+      "Num removed:  1440\n",
       "Round  3\n",
-      "Num removed:  0\n",
-      "Num removed:  0\n",
-      "Num removed:  0\n",
-      "Num removed:  0\n",
-      "Num removed:  0\n",
+      "Num removed:  1\n",
+      "Num removed:  17\n",
+      "Num removed:  7\n",
+      "Num removed:  49\n",
+      "Num removed:  585\n",
       "Round  4\n",
+      "Num removed:  2\n",
+      "Num removed:  40\n",
+      "Num removed:  17\n",
+      "Num removed:  119\n",
+      "Num removed:  795\n",
+      "Round  5\n",
+      "Num removed:  2\n",
+      "Num removed:  38\n",
+      "Num removed:  17\n",
+      "Num removed:  119\n",
+      "Num removed:  1878\n",
+      "Round  6\n",
+      "Num removed:  0\n",
+      "Num removed:  0\n",
+      "Num removed:  0\n",
+      "Num removed:  0\n",
+      "Num removed:  0\n",
+      "Round  7\n",
       "Num removed:  0\n",
       "Num removed:  0\n",
       "Num removed:  0\n",
@@ -426,7 +515,7 @@
     "min_games = 25\n",
     "\n",
     "# Repeat to remove teams that fall below 25 games when others are removed\n",
-    "for i in range(5):\n",
+    "for i in range(8):\n",
     "    print(\"Round \",i)\n",
     "    team_record = build_team_record_df(teams,demos)\n",
     "    few_games_team_ids = team_record[team_record['TotalGames']<min_games]['TeamId']\n",
@@ -441,18 +530,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(180, 9)\n",
-      "(32563, 8)\n",
-      "(4658, 15)\n",
-      "(10163, 17)\n",
-      "(334483, 12)\n"
+      "(165, 9)\n",
+      "(25179, 8)\n",
+      "(3598, 15)\n",
+      "(8758, 17)\n",
+      "(286850, 12)\n"
      ]
     }
    ],
@@ -468,12 +557,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Save clean csv's"
+    "### Remove Updated and Created"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demos = demos.drop(['Created','Updated'],axis=1)\n",
+    "map_picks = map_picks.drop(['Created','Updated'],axis=1)\n",
+    "matches = matches.drop(['Created','Updated'],axis=1)\n",
+    "teams = teams.drop(['Created','Updated'],axis=1)\n",
+    "players = players.drop(['Created','Updated'],axis=1)\n",
+    "player_demos = player_demos.drop(['Created','Updated'],axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save clean csv's"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -485,7 +595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,13 +606,6 @@
     "players.to_csv(out_dir+'players.csv',index=False)\n",
     "player_demos.to_csv(out_dir+'player_demos.csv',index=False)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
The notebook performs the following cleaning:

- Remove match IDs without map_picks data (~26 matches)
- Remove match IDs involving the 3 other maps (~5 matches)
- Remove match IDs where DecisionOrder = 1 and Decision = Pick (~3 matches) 
- Remove everything involving team IDs with fewer than 25 games ( ~1500 matches)

The above were removed from all relevant tables. 

The notebook also saves all tables (including players.csv which is untouched in the cleaning) with headers, and removes Updated/Created columns.

The cleaned csv's are [HERE](https://drive.google.com/file/d/1SvZXay-yrBhOg64kJPNN-ggpUu4f4oV6/view?usp=sharing) (Updated for most recent cleaning)

The notebook should run from top to bottom once the directories (data_dir and out_dir)  are configured. 