### PR TITLE
Proportion and 0-1 rewards

### DIFF
--- a/context_engineering_functions.py
+++ b/context_engineering_functions.py
@@ -39,6 +39,22 @@ def get_basic_rewards(map_picks, demos):
 
     return map_picks
 
+def get_proportion_rewards(map_picks, demos):
+    map_picks =  pd.merge(map_picks,
+                          demos[['MatchId', 'MapName', 'WinnerScore', 'LoserScore']], 
+                          how = 'left', 
+                          left_on = ['MatchId', 'MapName'], 
+                          right_on = ['MatchId', 'MapName'],
+                          suffixes = (None, '_right'))
+    #proportion of matches won
+    map_picks['Y_reward'] = (map_picks.WinnerScore - map_picks.WinnerScore ) / (map_picks.WinnerScore + map_picks.WinnerScore)
+
+    #drop extra WinnerId column since we no longer need it
+    map_picks.dropna(inplace= True, axis = 0)
+    map_picks.drop(labels = ['WinnerId'], axis = 1, inplace = True)
+
+    return map_picks
+
 
 def create_basic_triples(data_directory, save = False):
     map_picks = pd.read_csv(os.path.join(data_directory, 'map_picks.csv'), header = None)

--- a/context_engineering_functions.py
+++ b/context_engineering_functions.py
@@ -39,8 +39,8 @@ def get_basic_rewards(map_picks, demos):
     #for picks, if winner is same as picker, reward 1
 
     map_picks['MapWinnerId'] = np.where(map_picks.WinnerScore > map_picks.LoserScore, 
-                                    map_picks.WinnerId, 
-                                    map_picks.LoserId)
+                                      map_picks.WinnerId, 
+                                      map_picks.LoserId)
 
     map_picks['Y_reward'] = (map_picks.DecisionTeamId == map_picks.MapWinnerId).astype(int)
 
@@ -52,13 +52,25 @@ def get_basic_rewards(map_picks, demos):
 
 def get_proportion_rewards(map_picks, demos):
     map_picks =  pd.merge(map_picks,
-                          demos[['MatchId', 'MapName', 'WinnerScore', 'LoserScore']], 
+                          demos[['MatchId', 
+                                'MapName', 
+                                'WinnerId',
+                                'WinnerScore',
+                                'LoserId', 
+                                'LoserScore']], 
                           how = 'left', 
                           left_on = ['MatchId', 'MapName'], 
                           right_on = ['MatchId', 'MapName'],
                           suffixes = (None, '_right'))
+
+    map_picks['MapWinnerId'] = np.where(map_picks.WinnerScore > map_picks.LoserScore, 
+                                      map_picks.WinnerId, 
+                                      map_picks.LoserId)
+
     #proportion of matches won
-    map_picks['Y_reward'] = (map_picks.WinnerScore - map_picks.LoserScore ) / (map_picks.WinnerScore + map_picks.LoserScore)
+    map_picks['Y_reward'] = np.where(map_picks.MapWinnerId == map_picks.DecisionTeamId,
+                                    (map_picks.WinnerScore - map_picks.LoserScore ) / (map_picks.WinnerScore + map_picks.LoserScore),
+                                    (map_picks.LoserScore - map_picks.WinnerScore ) / (map_picks.WinnerScore + map_picks.LoserScore))             
 
     map_picks.dropna(inplace= True, axis = 0)
 

--- a/context_engineering_test.py
+++ b/context_engineering_test.py
@@ -4,7 +4,7 @@ import sys
 
 
 def main(datapath):
-    context = create_basic_triples(datapath, save = False)
+    context = cef.create_basic_triples(datapath, save = False)
     print(context.head(20))
 
 

--- a/context_engineering_test.py
+++ b/context_engineering_test.py
@@ -4,7 +4,7 @@ import sys
 
 
 def main(datapath):
-    context = cef.create_basic_triples(datapath, save = False)
+    context = cef.create_basic_triples(datapath, reward_function = cef.get_proportion_rewards,save = False)
     print(context.head(20))
 
 


### PR DESCRIPTION
I changed the logic for the 0-1 rewards, so instead of seeing if DecisionTeamId is the same to WinnerId, I created a MapWinnerId, and saw if DecisionTeamId is the same as MapWinnerId.

For the proportion rewards, the reward is proportion of games the Deciding Team Won by or Lost by. Not sure if this is what you had in mind, just let me know I can tweak it!