### PR TITLE
Fix bandit

### DIFF
--- a/bandit-test.ipynb
+++ b/bandit-test.ipynb
@@ -291,23 +291,12 @@
    "execution_count": 8,
    "id": "through-royal",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "rewards_actually_received = A[Y.astype(bool)]\n",
-    "predictions = bandit.predict(X[Y.astype(bool)], deterministic=False)\n",
-    "result = (predictions == rewards_actually_received).sum()\n",
-    "result"
+    "# rewards_actually_received = A[Y.astype(bool)]\n",
+    "# predictions = bandit.predict(X[Y.astype(bool)], deterministic=False)\n",
+    "# result = (predictions == rewards_actually_received).sum()\n",
+    "# result"
    ]
   },
   {
@@ -318,7 +307,7 @@
    "outputs": [],
    "source": [
     "for i in range(X.shape[0]):\n",
-    "    bandit.update_theta(X[i].reshape(1, -1), A[i], Y[i].reshape(-1, 1))"
+    "    bandit.update_theta(X[i].reshape(1, -1), A[i], Y[i])"
    ]
   },
   {
@@ -344,8 +333,8 @@
      "output_type": "stream",
      "text": [
       "Probabilities for random row after training: \n",
-      "[[0.         0.29938519 0.2238775  0.28259492 0.         0.\n",
-      "  0.1941424 ]]\n",
+      "[[0.         0.29443105 0.21140927 0.23522578 0.         0.\n",
+      "  0.2589339 ]]\n",
       "Selected action: \n",
       "[1]\n",
       "Actual action and reward for random row: \n",
@@ -368,22 +357,11 @@
    "execution_count": 12,
    "id": "bacterial-customs",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "predictions = bandit.predict(X[Y.astype(bool)], deterministic=False)\n",
-    "result = (predictions == rewards_actually_received).sum()\n",
-    "result"
+    "# predictions = bandit.predict(X[Y.astype(bool)], deterministic=False)\n",
+    "# result = (predictions == rewards_actually_received).sum()\n",
+    "# result"
    ]
   },
   {

--- a/bandit-test.ipynb
+++ b/bandit-test.ipynb
@@ -1,0 +1,419 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "stone-oracle",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished Basic Context Engineering\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from context_engineering_functions import create_basic_triples\n",
+    "\n",
+    "context = create_basic_triples('csgo_clean', save=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "palestinian-communication",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>MatchId</th>\n",
+       "      <th>de_dust2_is_available</th>\n",
+       "      <th>de_inferno_is_available</th>\n",
+       "      <th>de_mirage_is_available</th>\n",
+       "      <th>de_nuke_is_available</th>\n",
+       "      <th>de_overpass_is_available</th>\n",
+       "      <th>de_train_is_available</th>\n",
+       "      <th>de_vertigo_is_available</th>\n",
+       "      <th>DecisionTeamId</th>\n",
+       "      <th>OtherTeamId</th>\n",
+       "      <th>DecisionOrder</th>\n",
+       "      <th>X_Action</th>\n",
+       "      <th>Y_reward</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>4</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>12</td>\n",
+       "      <td>6</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>4</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>6</td>\n",
+       "      <td>12</td>\n",
+       "      <td>4</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9</td>\n",
+       "      <td>5</td>\n",
+       "      <td>3</td>\n",
+       "      <td>6</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>5</td>\n",
+       "      <td>9</td>\n",
+       "      <td>4</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>7</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>11</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   MatchId  de_dust2_is_available  de_inferno_is_available  \\\n",
+       "0        4                      1                        1   \n",
+       "1        4                      0                        1   \n",
+       "3        5                      0                        1   \n",
+       "4        5                      0                        1   \n",
+       "6        7                      1                        1   \n",
+       "\n",
+       "   de_mirage_is_available  de_nuke_is_available  de_overpass_is_available  \\\n",
+       "0                       1                     1                         0   \n",
+       "1                       1                     1                         0   \n",
+       "3                       1                     1                         0   \n",
+       "4                       1                     1                         0   \n",
+       "6                       1                     1                         0   \n",
+       "\n",
+       "   de_train_is_available  de_vertigo_is_available  DecisionTeamId  \\\n",
+       "0                      1                        0              12   \n",
+       "1                      1                        0               6   \n",
+       "3                      1                        1               9   \n",
+       "4                      1                        0               5   \n",
+       "6                      1                        0               4   \n",
+       "\n",
+       "   OtherTeamId  DecisionOrder  X_Action  Y_reward  \n",
+       "0            6              3         0         0  \n",
+       "1           12              4         3         1  \n",
+       "3            5              3         6         1  \n",
+       "4            9              4         3         0  \n",
+       "6           11              3         1         1  "
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "context.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "frequent-territory",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(8755, 13)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "context.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "honest-cooper",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "context.reset_index(drop=True, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "irish-slope",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bandit import Bandit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "civic-memory",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Probabilities for random row: \n",
+      "[[0.   0.25 0.25 0.25 0.   0.   0.25]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# do we need a train test split?\n",
+    "\n",
+    "cols = [col for col in context if col.endswith('is_available')]\n",
+    "\n",
+    "X = context[cols].values\n",
+    "A = context['X_Action'].values\n",
+    "Y = context['Y_reward'].values\n",
+    "\n",
+    "n_arms = 7\n",
+    "\n",
+    "# randomly chosen by dice roll\n",
+    "n = 4569\n",
+    "# n = np.random.choice(context.index)\n",
+    "\n",
+    "bandit = Bandit(X.shape[1], n_arms, step_size=0.01)\n",
+    "\n",
+    "print('Probabilities for random row: ')\n",
+    "print(bandit.predict_proba(X[n]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "normal-moses",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(4569, 3, 1)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n, A[n], Y[n]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "through-royal",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rewards_actually_received = A[Y.astype(bool)]\n",
+    "predictions = bandit.predict(X[Y.astype(bool)], deterministic=False)\n",
+    "result = (predictions == rewards_actually_received).sum()\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "detailed-sending",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(X.shape[0]):\n",
+    "    bandit.update_theta(X[i].reshape(1, -1), A[i], Y[i].reshape(-1, 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "entertaining-madonna",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# for i in range(10000):\n",
+    "#     bandit.update_theta(X[n].reshape(1, -1), A[n], Y[n].reshape(-1, 1))\n",
+    "# will force action 3 - since we're observing 10k times that action 3 will reward with 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "alpine-loading",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Probabilities for random row after training: \n",
+      "[[0.         0.29938519 0.2238775  0.28259492 0.         0.\n",
+      "  0.1941424 ]]\n",
+      "Selected action: \n",
+      "[1]\n",
+      "Actual action and reward for random row: \n",
+      "Action: 3, reward: 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Probabilities for random row after training: ')\n",
+    "print(bandit.predict_proba(X[n]))\n",
+    "print('Selected action: ')\n",
+    "print(bandit.predict(X[n]))\n",
+    "\n",
+    "print('Actual action and reward for random row: ')\n",
+    "print(f'Action: {A[n]}, reward: {Y[n]}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "bacterial-customs",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions = bandit.predict(X[Y.astype(bool)], deterministic=False)\n",
+    "result = (predictions == rewards_actually_received).sum()\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "existing-officer",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/bandit.py
+++ b/bandit.py
@@ -15,36 +15,127 @@ class Bandit(object):
         self.iters = 0
 
         # start at uniform
-        self.theta = np.zeros((self.n_features, self.n_arms))
-        
+        # theta shape: (n_arms,)
+        self.theta = np.zeros((self.n_features + 1,))
+
     @property
     def current_baseline(self):
+        """
+        Return current baseline value.
+
+        The baseline is just the running average of the rewards seen so far.
+
+        input: None
+
+        output: curr_baseline, current baseline. Shape: (1,)
+        """
         return (self.reward_sum / self.iters
                 if self.baseline and self.iters
                 else 0)
-        
+
+    def _phi(self, X, a):
+
+        if X.ndim == 1:
+            X = X.reshape(1, -1)
+
+        actions = np.ones((X.shape[0], 1)) * a
+        return np.concatenate([X, actions], axis=1)
+
+    def prefs(self, X):
+        """
+        Return the bandit's preferences for each action, for each context in X.
+
+        input: X, contexts. Shape: (n_contexts, n_features)
+
+        output: prefs, preferences. Shape: (n_contexts, n_arms)
+        """
+
+        phis = np.stack([self._phi(X, a)
+                         for a in range(self.n_arms)],
+                        axis=1).squeeze().T
+
+        return self.theta.T @ phis
+
     def predict_proba(self, X):
-        probabilities = softmax((X @ self.theta).reshape(-1, self.n_arms),
+        """
+        Return probabilities for each action for each context in X.
+
+        input: X, contexts. Shape: (n_contexts, n_features)
+
+        output: probs, probabilities per action. Shape: (n_contexts, n_arms)
+        """
+
+        prefs = self.prefs(X.reshape(-1, self.n_features))
+
+        # use softmax to get probabilities from prefs
+        probabilities = softmax(prefs.reshape(-1, self.n_arms),
                                 axis=1)
+        # get only possible maps
+        # for now the context is just which maps are possible
         possible_maps = probabilities * X
+        # re-normalize
         possible_maps /= possible_maps.sum()
         return possible_maps
     
     def predict(self, X, deterministic=True):
+        """
+        Return prediction of an action for each context in X.
+
+        input: X, contexts. Shape: (n_contexts, n_features)
+
+        output: action, action chosen per context. Shape: (n_contexts,)
+        """
+
         predictions = self.predict_proba(X)
+
+        # if we're deterministic, just pick the highest-probability action
         if deterministic:
             return predictions.argmax(axis=1)
+
+        # otherwise, pick randomly from the distribution given by the probs
+        # equivalent to using np.random.choice(),
+        # but with per-row probabilities
         cumsum = predictions.cumsum(axis=1)
         random_val = np.random.random_sample(len(cumsum))
         binarized = (cumsum.T < random_val).astype(int).sum(axis=0)
         return binarized
     
-    def theta_gradient(self, X, action):
-        return np.eye(self.n_arms)[action].squeeze() - self.predict_proba(X)
+    def _gradient(self, X, action):
+        """
+        Return the gradient of log of pi with respect to contexts X
+        and actions A.
+
+        input: X, contexts. Shape: (n_contexts, n_features)
+               action, actions actually taken. Shape: (n_contexts,)
+
+        output: grad, gradient of theta. Shape: (n_arms,)
+        """
+        # should return \nabla log(pi(A_t|X_t))
+
+        # precalc
+        phis = [self._phi(X, i) for i in range(self.n_arms + 1)]
+        exps = [np.exp(self.theta.T * phis[i])
+                for i in range(self.n_arms + 1)]
+        phi = phis[action]
+
+        numerator = sum([phis[i] * exps[i]
+                         for i in range(self.n_arms + 1)])
+        denominator = sum(exps).sum()  # is an array
+        
+        return phi - numerator / denominator
     
     def update_theta(self, X, action, reward):
+        """
+        Update theta according to the context/action/reward triplets given.
+
+        input: X, contexts. Shape: (n_contexts, n_features)
+               action, actions actually taken. Shape: (n_contexts,)
+               reward, rewards received for the actions. Shape: (n_contexts,)
+
+        output: None
+        """
         self.reward_sum += reward.sum()
         self.iters += len(reward)
         r_t = reward.T - self.current_baseline
-        gradient = r_t @ self.theta_gradient(X, action)
-        self.theta[action] += self.step_size * gradient
+        gradient = r_t @ self._gradient(X, action)
+        self.theta += self.step_size * gradient.squeeze()

--- a/bandit.py
+++ b/bandit.py
@@ -24,7 +24,11 @@ class Bandit(object):
                 else 0)
         
     def predict_proba(self, X):
-        return softmax((X @ self.theta).reshape(-1, self.n_arms), axis=1)
+        probabilities = softmax((X @ self.theta).reshape(-1, self.n_arms),
+                                axis=1)
+        possible_maps = probabilities * X
+        possible_maps /= possible_maps.sum()
+        return possible_maps
     
     def predict(self, X, deterministic=True):
         predictions = self.predict_proba(X)
@@ -42,4 +46,5 @@ class Bandit(object):
         self.reward_sum += reward.sum()
         self.iters += len(reward)
         r_t = reward.T - self.current_baseline
-        self.theta += self.step_size * r_t @ self.theta_gradient(X, action)
+        gradient = r_t @ self.theta_gradient(X, action)
+        self.theta[action] += self.step_size * gradient


### PR DESCRIPTION
This PR fixes the bandit so that it actually uses contextual bandit policy gradient. It also adds an example notebook.

I'm pretty sure this is supposed to be working - if you uncomment the cell that observes action 3 reward 1 10k times, then it will actually return action 3. It seems like the context just being given by the maps available has a preference for map index 1 no matter what, unless map index 1 is not available (of course).

I asked Prof. Rosenberg to confirm how `phi(x, a)` is supposed to work, but right now all it's doing is returning `(indicator[a] * X)`, that is, the actual value of `X` at entry `a` and 0 elsewhere. This seems odd to me but it's the only way I could reconcile what was in the slides with what makes sense in my head to parameterize this multinomial LR as.

Next steps:
- try out different contexts - requires rewriting some of the code to remove the maps that are not available, since that currently relies on the context *only* being the available maps
- possibly try different `phi(x, a)`
- evaluate the learned policy against the logging policy