### PR TITLE
Veto rewards

### DIFF
--- a/context_engineering_functions.py
+++ b/context_engineering_functions.py
@@ -154,7 +154,7 @@ def create_basic_pick_veto_triples(data_directory,
 
     if concat:
         
-        map_pick_context = pd.concat(rewards_list, axis = 0)
+        map_pick_context = pd.concat(rewards_list, axis = 0).sort_values(by = ['MatchId', 'DecisionOrder'])
         if save:
             map_pick_context.to_csv(os.path.join(data_directory, 'pick_veto_reward_triples.csv'))
         

--- a/context_engineering_test.py
+++ b/context_engineering_test.py
@@ -4,8 +4,9 @@ import sys
 
 
 def main(datapath):
-    context = cef.create_basic_triples(datapath, reward_function = cef.get_proportion_rewards,save = False)
-    print(context.head(20))
+    context = cef.create_basic_pick_veto_triples(datapath, concat = False, save = False)
+    print(context[0].head(20))
+    print(context[1].head(20))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've added the `get_veto_rewards` function to do the decaying weight over decision order as mentioned in discord. I have also added a `create_basic_pick_veto_triples` to get both the 0-1reward from map winner for picks and the decaying weights for the veto rewards. This function either returns a tuple of `(picks_triple,veto_triples)` or you can concat them into one large dataframe and save that dataframe. I did this fairly quickly, let me know if anything looks off!