### PR TITLE
removed matches where Picks and Removes were in wrong order

### DIFF
--- a/data_cleaning.ipynb
+++ b/data_cleaning.ipynb
@@ -310,8 +310,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Remove matches where Decision 1 was a Pick\n",
-    "This happens ~3 times"
+    "### Remove matches where DecisionOrder and Decision don't align\n",
+    "DecisionOrder 1,2,5,6 should be 'Remove' and DecisionOrder 3,4,7 should be 'Pick'"
    ]
   },
   {
@@ -320,7 +320,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wrong_decision_match_ids = list(map_picks[(map_picks['Decision']=='Pick') & (map_picks['DecisionOrder']==1)]['MatchId'])"
+    "wrong_decision_match_ids = list(map_picks[(map_picks['Decision']=='Pick') & ((map_picks['DecisionOrder'] == 1)|\n",
+    "                                                                             (map_picks['DecisionOrder'] == 2)|\n",
+    "                                                                             (map_picks['DecisionOrder'] == 5)|\n",
+    "                                                                             (map_picks['DecisionOrder'] == 6)\n",
+    "                                                                            )]['MatchId'])\n",
+    "\n",
+    "wrong_decision_match_ids.extend(list(map_picks[(map_picks['Decision']=='Remove') & ((map_picks['DecisionOrder'] == 3)|\n",
+    "                                                                                    (map_picks['DecisionOrder'] == 4)|\n",
+    "                                                                                    (map_picks['DecisionOrder'] == 7)\n",
+    "                                                                                   )]['MatchId']))"
    ]
   },
   {
@@ -332,10 +341,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Num removed:  8\n",
-      "Num removed:  240\n",
-      "Num removed:  3\n",
-      "Num removed:  21\n"
+      "Num removed:  1788\n",
+      "Num removed:  53477\n",
+      "Num removed:  1556\n",
+      "Num removed:  10855\n"
      ]
     }
    ],
@@ -356,10 +365,10 @@
      "output_type": "stream",
      "text": [
       "(636, 9)\n",
-      "(43684, 8)\n",
-      "(6254, 15)\n",
-      "(13105, 17)\n",
-      "(392400, 12)\n"
+      "(32850, 8)\n",
+      "(4701, 15)\n",
+      "(11325, 17)\n",
+      "(339163, 12)\n"
      ]
     }
    ],
@@ -401,10 +410,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Num removed:  1801\n",
-      "Num removed:  53867\n",
-      "Num removed:  1564\n",
-      "Num removed:  10861\n"
+      "Num removed:  33\n",
+      "Num removed:  990\n",
+      "Num removed:  17\n",
+      "Num removed:  68\n"
      ]
     }
    ],
@@ -425,10 +434,10 @@
      "output_type": "stream",
      "text": [
       "(636, 9)\n",
-      "(32823, 8)\n",
-      "(4690, 15)\n",
-      "(11304, 17)\n",
-      "(338533, 12)\n"
+      "(32782, 8)\n",
+      "(4684, 15)\n",
+      "(11292, 17)\n",
+      "(338173, 12)\n"
      ]
     }
    ],
@@ -461,16 +470,16 @@
      "text": [
       "Round  0\n",
       "Num removed:  447\n",
-      "Num removed:  2128\n",
-      "Num removed:  912\n",
-      "Num removed:  6384\n",
-      "Num removed:  39687\n",
+      "Num removed:  2123\n",
+      "Num removed:  910\n",
+      "Num removed:  6370\n",
+      "Num removed:  39612\n",
       "Round  1\n",
       "Num removed:  16\n",
-      "Num removed:  258\n",
-      "Num removed:  112\n",
-      "Num removed:  784\n",
-      "Num removed:  7298\n",
+      "Num removed:  256\n",
+      "Num removed:  111\n",
+      "Num removed:  777\n",
+      "Num removed:  7268\n",
       "Round  2\n",
       "Num removed:  3\n",
       "Num removed:  65\n",
@@ -538,10 +547,10 @@
      "output_type": "stream",
      "text": [
       "(165, 9)\n",
-      "(25179, 8)\n",
-      "(3598, 15)\n",
-      "(8758, 17)\n",
-      "(286850, 12)\n"
+      "(25159, 8)\n",
+      "(3595, 15)\n",
+      "(8753, 17)\n",
+      "(286595, 12)\n"
      ]
     }
    ],
@@ -575,6 +584,60 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>MatchId</th>\n",
+       "      <th>MapName</th>\n",
+       "      <th>DecisionOrder</th>\n",
+       "      <th>DecisionTeamId</th>\n",
+       "      <th>OtherTeamId</th>\n",
+       "      <th>Decision</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [MatchId, MapName, DecisionOrder, DecisionTeamId, OtherTeamId, Decision]\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "map_picks[(map_picks['DecisionOrder']==5) & (map_picks['Decision']=='Pick')]"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -583,7 +646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -595,7 +658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/data_cleaning.py
+++ b/data_cleaning.py
@@ -162,10 +162,19 @@ demos = remove_records(demos,['MapName'],weird_maps)
 map_picks = remove_records(map_picks,['MapName'],weird_maps)
 player_demos = remove_records(player_demos,['MapName'],weird_maps)
 
-### Remove matches where Decision 1 was a Pick
-# This happens ~3 times
-
-wrong_decision_match_ids = list(map_picks[(map_picks['Decision']=='Pick') & (map_picks['DecisionOrder']==1)]['MatchId'])
+### Remove matches where DecisionOrder and Decision don't align
+# DecisionOrder 1,2,5,6 should be 'Remove' and DecisionOrder 3,4,7 should be 'Pick'
+# Picks in 1,2,5,6
+wrong_decision_match_ids = list(map_picks[(map_picks['Decision']=='Pick') & ((map_picks['DecisionOrder'] == 1)|
+                                                                             (map_picks['DecisionOrder'] == 2)|
+                                                                             (map_picks['DecisionOrder'] == 5)|
+                                                                             (map_picks['DecisionOrder'] == 6)
+                                                                            )]['MatchId'])
+# Removes in 3,4,7
+wrong_decision_match_ids.extend(list(map_picks[(map_picks['Decision']=='Remove') & ((map_picks['DecisionOrder'] == 3)|
+                                                                                    (map_picks['DecisionOrder'] == 4)|
+                                                                                    (map_picks['DecisionOrder'] == 7)
+                                                                                   )]['MatchId']))
 
 demos = remove_records(demos,['MatchId'],wrong_decision_match_ids)
 player_demos = remove_records(player_demos,['MatchId'],wrong_decision_match_ids)


### PR DESCRIPTION
Per @charlesoblack 's find, there were some picks occurring in DecisionOrder = [1,2,5,6]. There were also a few Removes occuring in DecisionOrder = [3,4,7]. Added a few lines to both the notebook and the .py file to remove them.  Updated clean data is [here](https://drive.google.com/file/d/163O59YXKEdR9AdBmkY_twwluQIczeXB6/view?usp=sharing).

FYI, most of the diff below is in the output of the notebook.  Only change was a comment and 2 lines of code.