### PR TITLE
Fix get available maps

### DIFF
--- a/context_engineering_functions.py
+++ b/context_engineering_functions.py
@@ -15,8 +15,12 @@ def get_available_maps(df):
     rolling_df = (1 - (manip_df.groupby('MatchId')[map_names]
                                .rolling(7, min_periods=0)
                                .sum()  # rolling sum
-                               .shift(1, fill_value=0)  # shift down so we know what's available
+                               .reset_index(level = 0)
+                               .groupby('MatchId')
+                               .shift(1, fill_value = 0)# shift down so we know what's available
                                ))
+    rolling_df.drop('MatchId',axis = 1, inplace = True)
+    
     rolling_df = rolling_df.astype(int)
     rolling_df.reset_index(drop = True, inplace=True)
     rolling_df.columns = [x + '_is_available' for x in rolling_df.columns]

--- a/context_engineering_functions.py
+++ b/context_engineering_functions.py
@@ -20,7 +20,7 @@ def get_available_maps(df):
                                .shift(1, fill_value = 0)# shift down so we know what's available
                                ))
     rolling_df.drop('MatchId',axis = 1, inplace = True)
-    
+
     rolling_df = rolling_df.astype(int)
     rolling_df.reset_index(drop = True, inplace=True)
     rolling_df.columns = [x + '_is_available' for x in rolling_df.columns]
@@ -167,6 +167,10 @@ def create_basic_pick_veto_triples(data_directory,
 
 
     else:
+        if save:
+            rewards_list[0].to_csv(os.path.join(data_directory, 'pick_reward_triples.csv'))
+            rewards_list[1].to_csv(os.path.join(data_directory, 'veto_reward_triples.csv'))
+
         return tuple(rewards_list)
 
 


### PR DESCRIPTION
As noticed by @mihamerstan, `get_available_maps` had a bug where the `.shift` would cause all `decision_order = 1` to have a row of 0s in the resulting dataframe for all matches after the first row(examples in discord).

Apparently reseting the index and then grouping by again before shifting fixes it(I have a feeling that when you were originally shifting @charlesoblack this was post-aggregating with the sum, so it just shifting every row down without grouping by the intended MatchId). It should work now. I also added the save logic for the nonconcatinated df in case it was necessary, but not a big deal!